### PR TITLE
스폰서스토어 proposal 변수 업데이트 가능하게 변경

### DIFF
--- a/components/organisms/SponsorForm/Stage2.tsx
+++ b/components/organisms/SponsorForm/Stage2.tsx
@@ -2,7 +2,6 @@ import styled from '@emotion/styled'
 import { FormWrapper, SelectWrapper } from 'components/atoms/ContentWrappers'
 import { IntlText } from 'components/atoms/IntlText'
 import { StageButtonGroup } from 'components/organisms/CFPForm/StageButtonGroup'
-import { SponsorFormStage } from 'lib/stores/Sponsor/SponsorStore'
 import { toJS } from 'mobx'
 import { inject, observer } from 'mobx-react'
 import { StoresType } from 'pages/_app'
@@ -53,11 +52,12 @@ export default class CFPFormStage2 extends React.Component<PropsType> {
     this.props.scrollRef && window.scrollTo(0, this.props.scrollRef.offsetTop)
   }
 
-  getFilename(url) {
+  getFilename(url: string) {
     if (url) {
-      return url.substring(url.lastIndexOf('/') + 1);
+      return url.substring(url.lastIndexOf('/') + 1)
     }
-    return '';
+
+    return ''
   }
 
   render() {
@@ -315,7 +315,7 @@ export default class CFPFormStage2 extends React.Component<PropsType> {
             </IntlText>
           </label>
           <InputDesc><a href={proposal.logoImage}>{this.getFilename(proposal.logoImage)}</a></InputDesc>
-          
+
           <label
               htmlFor='logo_image_upload'
               className='file-upload__label'

--- a/lib/stores/Sponsor/SponsorNode.ts
+++ b/lib/stores/Sponsor/SponsorNode.ts
@@ -28,10 +28,6 @@ export class SponsorNode {
     @observable submitted: boolean = false
     @observable accepted: boolean = false
 
-    constructor(data: Partial<SponsorNode>) {
-        Object.assign(this, data);
-    }
-    
     @action
     setNameKor(newNameKor: string) {
         this.nameKo = newNameKor

--- a/lib/stores/Sponsor/SponsorStore.ts
+++ b/lib/stores/Sponsor/SponsorStore.ts
@@ -5,7 +5,7 @@ import { uploadLogoImage as uploadSponsorLogoImage } from 'lib/apollo_graphql/mu
 import { uploadLogoVector as uploadSponsorLogoVector } from 'lib/apollo_graphql/mutations/uploadLogoVector'
 import { getMySponsor } from 'lib/apollo_graphql/queries/getMySponsor'
 import { getSponsorLevels, SponsorLevelType } from 'lib/apollo_graphql/queries/getSponsorLevels'
-import { action, configure, observable } from 'mobx'
+import { action, configure, observable, set } from 'mobx'
 import { SponsorNode } from './SponsorNode'
 import * as _ from 'lodash'
 
@@ -45,7 +45,7 @@ export class SponsorStore {
     @action
     async retrieveMySponsorProposal() {
         const { data } = await getMySponsor(client)({})
-        this.proposal = new SponsorNode(data.mySponsor)
+        set(this.proposal, data.mySponsor as { [key: string]: any })
     }
 
     @action


### PR DESCRIPTION
스폰서스토어 proposal 변수 업데이트 가능하게 변경

- mySponsor 데이터 fetch한 후 값이 업데이트 되게끔 변경
- [mobx object api의 `set` 함수 사용](https://mobx.js.org/refguide/object-api.html)