### PR TITLE
fix: 나의 제안 목록의 마감 기한의 D-day 포맷 표시 오류

### DIFF
--- a/components/atoms/StatusBar.tsx
+++ b/components/atoms/StatusBar.tsx
@@ -50,7 +50,7 @@ const getStatusText = (openDate?: DateDTO, closeDate?: DateDTO, titleIntlKey?: s
 
   let statusMessage = intl.get('common.status.onProgress').d('진행 중입니다.')
   if (isFuture(openDate) && link) {
-    const diff = differenceInCalendarDays(new Date(), openDate)
+    const diff = differenceInCalendarDays(openDate, new Date())
 
     statusMessage = diff < 7
       ? intl.get('common.status.openBefore', { diff }).d(`시작까지 D${diff}!`)
@@ -64,7 +64,7 @@ const getStatusText = (openDate?: DateDTO, closeDate?: DateDTO, titleIntlKey?: s
   }
 
   if (closeDate) {
-    const diff = differenceInCalendarDays(new Date(), closeDate)
+    const diff = differenceInCalendarDays(closeDate, new Date())
     statusMessage = `${statusMessage} (${intl.get('common.status.closeAfter', { diff }).d(`마감까지 D${diff}`)})`
   }
 

--- a/components/molecules/ContributionTableRow.tsx
+++ b/components/molecules/ContributionTableRow.tsx
@@ -41,6 +41,7 @@ export default class ContributionTableRow extends React.Component<PropsType> {
         const isContributionAvailable = openDate && link
         const isBeforeOpening = openDate && isFuture(openDate) && link
         const isFinished = closeDate && isPast(closeDate)
+        const now = new Date()
 
         if (!isContributionAvailable) return '-'
 
@@ -63,20 +64,20 @@ export default class ContributionTableRow extends React.Component<PropsType> {
             return '미제출'
         } else {
             if (isBeforeOpening) {
-                const leftdDay = openDate && differenceInCalendarDays(new Date(), openDate)
-                const isBefore7days = leftdDay && leftdDay < 7
+                const daysDifference = openDate && differenceInCalendarDays(openDate, now)
+                const isBefore7days = daysDifference && daysDifference < 7
 
                 return isBefore7days
-                    ? intl.get('common.status.openBefore', { leftdDay }).d(`모집 시작 D${leftdDay}`)
+                    ? intl.get('common.status.openBefore', { diff: daysDifference }).d(`모집 시작 D-${daysDifference}`)
                     : intl.get('common.status.preparing').d('준비 중')
             }
 
             if (isFinished) return intl.get('common.status.closed').d('마감')
 
-            if (closeDate && differenceInCalendarDays(new Date(), closeDate) < 7) {
-                const leftDday = differenceInCalendarDays(new Date(), closeDate)
+            if (closeDate && differenceInCalendarDays(closeDate, now) < 7) {
+                const daysDifference = differenceInCalendarDays(closeDate, now)
 
-                return intl.get('common.status.closeAfter', { leftDday }).d(`마감 D-${leftDday}`)
+                return intl.get('common.status.closeAfter', { diff: daysDifference }).d(`마감 D-${ daysDifference}`)
             }
 
             return intl.get('common.status.onProgress').d('모집 중')

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -43,9 +43,9 @@
     "status": {
       "onProgress": "On Progress",
       "preparing": "Preparing",
-      "openBefore": "Open D{diff}",
+      "openBefore": "Open D-{diff}",
       "openToday": "Open Soon Today",
-      "closeAfter": "Close D{diff}",
+      "closeAfter": "Close D-{diff}",
       "closed": "Closed",
       "untilSelected": "Until Selected",
       "conferenceDays": "Conference Days"

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -25,6 +25,11 @@ import { fontCSS } from 'styles/font'
 global.Intl = IntlPolyfill
 require('intl/locale-data/jsonp/ko.js')
 
+const locales = {
+  'ko-KR': require('locales/ko-KR'),
+  'en-US': require('locales/en-US')
+}
+
 const intlWarningHandler = (message: string) => {
   if (message.includes('react-intl-universal key') &&
     message.includes(`not defined in ${LOCALE_KEY_KR}`)) {
@@ -64,10 +69,7 @@ class MyApp extends App {
     const currentLocale = query![URL_LOCALE_KEY] as string || LOCALE_KEY_KR
     intl.init({
       currentLocale,
-      locales: {
-        // tslint:disable-next-line:non-literal-require
-        [currentLocale]: require(`locales/${currentLocale}`)
-      },
+      locales,
       warningHandler: intlWarningHandler
     })
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,7 +24,7 @@
         "ignoreDefinitionFiles": true,
         "suppressWhileTypeErrorsPresent": false,
         "mockTypeScriptVersion": false
-      },
+      }
     ]
   }
 }


### PR DESCRIPTION
fixes #66 

en-US locale string에 전달되는 variable key 불일치로 값이 전달되지 않음:
- (en-US.json) 계산된 남은(지난) 날의 수 변수명을 변경
- (ContributionTableRow.ts) 변경된 변수명에 맞춰서 variable 전달

제안 테이블에서 남은 날짜를 계산할 때 (현재 - 마감/오픈날) 로 계산하여 음수 반환:
- (ContributionTableRow.ts) 좌우항을 바꿔서, 7일 후 마감/오픈이라면 7을 반환

Signed-off-by: cmygray <cmygray@gmail.com>