### PR TITLE
개인후원자명단에 업로드한 프로필 이미지를 사용하도록 수정

### DIFF
--- a/components/organisms/PatronList.tsx
+++ b/components/organisms/PatronList.tsx
@@ -23,6 +23,7 @@ class PatronList extends React.Component<PropsType> {
     if (!isPatronExist) return null
 
     return patrons.map(patron => {
+      const profileImg = patron.image ? patron.image : patron.avatarUrl
       const name = isLanguageKorean ? patron.nameKo : patron.nameEn
       const bio = isLanguageKorean ? patron.bioKo : patron.bioEn
       const organization = _.isEmpty(patron.organization) ? 'Patron Contributor' : patron.organization
@@ -30,7 +31,7 @@ class PatronList extends React.Component<PropsType> {
       return (
         <ProfileCard
           key={`patron_${patron.id}`}
-          profileImg={patron.avatarUrl}
+          profileImg={profileImg}
           name={name || 'Patron'}
           organization={organization}
           bio={bio || 'Thank you for your contribution.'}


### PR DESCRIPTION
사용자가 프로필이미지를 업로드 했었어도
개인후원자명단에서 이용되지 않은 점을 발견해서 수정했습니다.