### PR TITLE
feat: 개인후원자 이미지를 고정 비율로 표시하고, 에러 시 대체 이미지 표시

### DIFF
--- a/components/molecules/ProfileCard/index.tsx
+++ b/components/molecules/ProfileCard/index.tsx
@@ -24,12 +24,23 @@ const ProfileCardWrapper = styled.div`
 
 const ProfileImage = styled.div`
   width: 20%;
+  padding: 0 20px;
   text-align: center;
 
+  figure {
+    position: relative;
+    height: 0;
+    padding-top: 100%;
+  }
   img {
-    width: 100px;
+    object-fit: cover;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
     border-radius: 50%;
-    box-shadow: 0px 0px 20px #DFDFDF
+    box-shadow: 0px 0px 20px #DFDFDF;
   }
 
   @media (max-width: ${mobileWidth}) {
@@ -90,7 +101,9 @@ class ProfileCard extends React.Component<PropsType> {
     return (
       <ProfileCardWrapper>
         <ProfileImage>
-          <img src={profileImg} onError={this.handleImgError.bind(this)}/>
+          <figure>
+            <img src={profileImg} onError={this.handleImgError.bind(this)}/>
+          </figure>
         </ProfileImage>
         <ProfileDescription>
           <ProfileName>{name}</ProfileName>

--- a/components/molecules/ProfileCard/index.tsx
+++ b/components/molecules/ProfileCard/index.tsx
@@ -76,13 +76,21 @@ const ProfileOrganization = styled.div`
 `
 
 class ProfileCard extends React.Component<PropsType> {
+  handleImgError(e: any) {
+    const { name } = this.props
+    const FALLBACK_IMG_URL = `https://www.tinygraphs.com/squares/${name}?theme=seascape&numcolors=2&size=100&fmt=svg`
+
+    e.target.onerror = null
+    e.target.src = FALLBACK_IMG_URL
+  }
+
   render() {
     const { profileImg, name, organization, bio } = this.props
-    
+
     return (
       <ProfileCardWrapper>
         <ProfileImage>
-          <img src={profileImg} />
+          <img src={profileImg} onError={this.handleImgError.bind(this)}/>
         </ProfileImage>
         <ProfileDescription>
           <ProfileName>{name}</ProfileName>


### PR DESCRIPTION
fixes: #230 

tinygraphs.com 서비스를 사용해서 아바타를 생성했는데 이미지가 별로거나.. 투머치라고 생각하시면 `FALLBACK_IMG_URL` 값을 정적 리소스 경로나 다른 URL로 바꾸셔도 좋습니다.