### PR TITLE
fix: 후원사 배너 클릭 시 무한로딩 에러 수정

### DIFF
--- a/components/organisms/PatronList.tsx
+++ b/components/organisms/PatronList.tsx
@@ -1,25 +1,18 @@
 import { FlexColumnWrapper } from 'components/atoms/FlexWrapper'
 import { Loading } from 'components/atoms/Loading'
 import ProfileCard from 'components/molecules/ProfileCard'
-import i18next from 'i18next'
-import _ from 'lodash'
-import { observer } from 'mobx-react'
-import { StoresType } from 'pages/_app'
+import { isEmpty } from 'lodash'
 import React from 'react'
+import { PatronNode } from '../../lib/apollo_graphql/queries/getPatrons';
 
 type PropsType = {
-    stores: StoresType;
+    patrons: PatronNode[];
 }
 
-@observer
 class PatronList extends React.Component<PropsType> {
 
   renderPatronList = () => {
-    const { stores } = this.props
-    const { patrons } = stores.sponsorStore
-    const isPatronExist = !!!_.isNil(patrons)
-
-    if (!isPatronExist) return null
+    const { patrons } = this.props
 
     return patrons.map(patron => {
       const {image, name, bio, organization } = patron
@@ -37,8 +30,8 @@ class PatronList extends React.Component<PropsType> {
   }
 
   render() {
-    const { stores } = this.props
-    if (!stores.sponsorStore.patrons || _.isEmpty(stores.sponsorStore.patrons)) {
+    const { patrons } = this.props
+    if (!patrons || isEmpty(patrons)) {
       return <Loading width={50} height={50}/>
     }
 

--- a/lib/stores/Sponsor/SponsorStore.ts
+++ b/lib/stores/Sponsor/SponsorStore.ts
@@ -95,8 +95,13 @@ export class SponsorStore {
     async retrieveSponsors() {
         const response = await getSponsors(client)({})
         if (response.data.sponsors) {
-            this.sponsors = response.data.sponsors as getSponsors_sponsors[]
+            this.setSponsors(response.data.sponsors as PublicSponsorNode[])
         }
+    }
+
+    @action
+    setSponsors(sponsors: PublicSponsorNode[]) {
+        this.sponsors = sponsors
     }
 
     @action

--- a/pages/sponsor/detail.tsx
+++ b/pages/sponsor/detail.tsx
@@ -4,13 +4,12 @@ import {PageDefaultPropsType} from 'types/PageDefaultPropsType'
 import PageTemplate from 'components/templates/PageTemplate'
 import Footer from 'components/organisms/Footer'
 import Header from 'components/organisms/Header'
-import {H1, H2, Paragraph, Section} from 'components/atoms/ContentWrappers'
+import {H1, H2, Section} from 'components/atoms/ContentWrappers'
 import {withRouter} from 'next/router'
 import {Loading} from 'components/atoms/Loading'
 import styled from '@emotion/styled'
 import MarkdownWrapper from 'components/atoms/MarkdownWrapper'
 import gql from 'graphql-tag'
-import { Query } from 'react-apollo'
 
 const GET_SPONSOR = gql`
 query Sponsor($id: ID!) {
@@ -57,32 +56,20 @@ const SponsorContent = (props: any) => {
 @inject('stores')
 @observer
 export default class SponsorDetail extends React.Component<PageDefaultPropsType> {
-  async componentDidMount() {
-  }
+  render() {
+    const { id } = this.props.router.query
+    const sponsor = this.props.stores.sponsorStore.sponsors.find(
+      sponsor => sponsor.id === id
+    )
 
-  renderSponsor = () => {
-    const id = this.props.router.query.id
     return (
       <PageTemplate
         header={<Header title='후원사 상세 :: 파이콘 한국 2019' intlKey='sponsor.detail.pageTitle'/>}
         footer={<Footer/>}
       >
-        <Query query={GET_SPONSOR} variables={{ id }}>
-          {({ loading, error, data }) => {
-            if (loading || error) return (<Loading width={50} height={50}/>);
-            return (
-              <SponsorContent sponsor={data.sponsor}/>
-            )
-          }}
-        </Query>
-        
-      </PageTemplate>
-    )
-  }
+        <SponsorContent sponsor={sponsor}/>
 
-  render() {
-    return (
-        this.renderSponsor()
+      </PageTemplate>
     )
   }
 }

--- a/pages/sponsor/patrons.tsx
+++ b/pages/sponsor/patrons.tsx
@@ -27,6 +27,7 @@ export class Patrons extends React.Component<PageDefaultPropsType> {
 
   render() {
     const { t, stores } = this.props
+    const { patrons } = stores.sponsorStore
 
     return (
       <PageTemplate
@@ -39,7 +40,7 @@ export class Patrons extends React.Component<PageDefaultPropsType> {
               <AlertBar text={t('sponsor:patron.waitingAlert')} />
             </Section>
           : <Section>
-              <PatronList stores={stores} />
+              <PatronList patrons={patrons} />
             </Section>
         }
       </PageTemplate>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1245,6 +1245,7 @@
 "@wry/equality@^0.1.2":
   version "0.1.9"
   resolved "https://registry.yarnpkg.com/@wry/equality/-/equality-0.1.9.tgz#b13e18b7a8053c6858aa6c85b54911fb31e3a909"
+  integrity sha512-mB6ceGjpMGz1ZTza8HYnrPGos2mC6So4NhS1PtZ8s4Qt0K7fBiIGhpSxUbQmhwcSWE3no+bYxmI2OL6KuXYmoQ==
   dependencies:
     tslib "^1.9.3"
 
@@ -3306,6 +3307,7 @@ fast-deep-equal@^2.0.1:
 fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
+  integrity sha1-1RQsDK7msRifh9OnYREGT4bIu/I=
 
 fast-levenshtein@^2.0.6:
   version "2.0.6"
@@ -4650,6 +4652,7 @@ lodash.identity@3.0.0:
 lodash.isequal@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
+  integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
 
 lodash.merge@^4.6.1:
   version "4.6.1"
@@ -5992,10 +5995,12 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.2.7:
     strip-json-comments "~2.0.1"
 
 react-apollo@^2.4.1:
-  version "2.5.6"
-  resolved "https://registry.yarnpkg.com/react-apollo/-/react-apollo-2.5.6.tgz#98a59d0eea31432ed001e6a033e11a58139ffc31"
+  version "2.5.8"
+  resolved "https://registry.yarnpkg.com/react-apollo/-/react-apollo-2.5.8.tgz#c7a593b027efeefdd8399885e0ac6bec3b32623c"
+  integrity sha512-60yOQrnNosxU/tRbOxGDaYNLFcOKmQqxHPhxyvKTlGIaF/rRCXQRKixUgWVffpEupSHHD7psY5k5ZOuZsdsSGQ==
   dependencies:
     apollo-utilities "^1.3.0"
+    fast-json-stable-stringify "^2.0.0"
     hoist-non-react-statics "^3.3.0"
     lodash.isequal "^4.5.0"
     prop-types "^15.7.2"
@@ -6056,6 +6061,7 @@ react-intl@^2.8.0:
 react-is@^16.3.2, react-is@^16.7.0, react-is@^16.8.1:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
+  integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
 
 react-lifecycles-compat@^3.0.2, react-lifecycles-compat@^3.0.4:
   version "3.0.4"
@@ -7089,6 +7095,7 @@ ts-invariant@^0.3.2:
 ts-invariant@^0.4.0, ts-invariant@^0.4.2:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.4.4.tgz#97a523518688f93aafad01b0e80eb803eb2abd86"
+  integrity sha512-uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==
   dependencies:
     tslib "^1.9.3"
 
@@ -7122,6 +7129,7 @@ tslib@1.9.0:
 tslib@^1, tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
+  integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
 
 tslint-config-prettier@^1.17.0:
   version "1.18.0"


### PR DESCRIPTION
before:
- 후원사 배너를 클릭하면 sponsor/detail?id={SPONSOR_ID} 으로 이동하고 무한로딩

after:
- 후원사 배너를 클릭하면 sponsor/detail?name={SPONSOR_NAME} 으로 이동하고 후원사 정보 표시

proposed changes:
- 후원사 상세정보를 찾을 때 id 대신 name을 사용하여 url에 후원사 이름을 표시합니다
- page 레벨 컴포넌트에 결합된 Query 컴포넌트의 fetch 로직을 분리하고 스토어 액션을 사용합니다

mobx 사용에 익숙하지 않아서 page 컴포넌트 로직에서 액션을 호출하지 않았습니다. (initailize 된 SponsorStore를 참조해도 상세정보를 찾을 수 있었습니다.) 배포 환경에서 어찌 될 지 확인이 필요합니다.

REF: #173 