### PR TITLE
스프린트 프로젝트 URL에 링크 추가

### DIFF
--- a/pages/program/sprint-detail.tsx
+++ b/pages/program/sprint-detail.tsx
@@ -98,7 +98,9 @@ const SprintDetailContent = (props) => {
             sprint.opensourceUrl &&
             <ProgramTableRow
               header={t('program:sprint.opensourceUrl')} >
-              { sprint.opensourceUrl }
+              <a href={ sprint.opensourceUrl } target="_blank">
+                { sprint.opensourceUrl }
+              </a>
             </ProgramTableRow>
           }
           {


### PR DESCRIPTION
스프린트 프로젝트 상세 페이지에서 프로젝트 URL이 나오긴 하는데, 링크가 안 걸려 있어서 URL을 복사하여 주소창에 붙여서 들어가야 하는 게 불편해서, 링크도 걸어봤습니다.

적용 이전:

![](https://user-images.githubusercontent.com/12431/61617944-bdc71400-aca6-11e9-85a3-a5d134e12193.png)

적용 이후:

![](https://user-images.githubusercontent.com/12431/61617956-c6b7e580-aca6-11e9-822c-5d9158fabbbc.png)