### PR TITLE
타임테이블 태그 스타일 변경

### DIFF
--- a/components/molecules/TimetableContentItem/StyledComponents.ts
+++ b/components/molecules/TimetableContentItem/StyledComponents.ts
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled'
+import { CORAL, GREEN, YELLOW } from 'styles/colors'
 import { mobileWidth } from 'styles/layout'
 
 export const TimeTableContentItem = styled.div<{
@@ -41,6 +42,7 @@ export const TimeTableContentItem = styled.div<{
       display: flex;
       flex: 5;
       justify-content: space-between;
+      flex-direction: column;
 
       .subject {
         padding: 0 20px;
@@ -55,11 +57,6 @@ export const TimeTableContentItem = styled.div<{
           padding-top: 5px;
         }
         ${props => !props.isBreaktime && 'cursor: pointer; &:hover { color: #088487; font-weight: 600; }'}
-      }
-
-      .tagWrapper {
-        display: flex;
-        align-items: center;
       }
     }
   }
@@ -77,14 +74,51 @@ export const TimeTableContentItem = styled.div<{
       height: 100%;
 
       .contentDetailWrapper {
-        display: flex;
-        align-items: center;
-
         .room,
         .subject {
           padding: 0 10px;
         }
       }
     }
+  }
+`
+
+export const TagWrapper = styled.div`
+  padding-left: 20px;
+  justify-content: flex-end;
+  width: 100%;
+  display: flex;
+  flex-flow: row wrap;
+  margin-top: 15px;
+  height: auto;
+
+  @media (max-width: ${mobileWidth}) {
+   padding-left: 10px;
+   justify-content: left;
+  }
+`
+
+export const Tag = styled.span`
+  color: white;
+  font-size: 12px;
+  border-radius: 3px;
+  padding: 3px 4px;
+  opacity: .9;
+  margin-right: 5px;
+  margin-bottom: 2px;
+  height: 20px;
+
+  &.beginner,
+  &.over10years {
+    background: ${GREEN};
+  }
+
+  &.intermediate,
+  &.over13years {
+    background: ${YELLOW};
+  }
+
+  &.experienced {
+    background: ${CORAL};
   }
 `

--- a/components/molecules/TimetableContentItem/index.tsx
+++ b/components/molecules/TimetableContentItem/index.tsx
@@ -1,10 +1,8 @@
 import * as React from 'react'
 
-import { Tag, TagWrapper } from 'components/molecules/Program/List'
 import Link from 'next/link'
-import { paths } from 'routes/paths'
 import { formatDateOnlyTime } from 'utils/formatDate'
-import { TimeTableContentItem } from './StyledComponents'
+import { Tag, TagWrapper, TimeTableContentItem } from './StyledComponents'
 
 type PropsType = {
   id: string;
@@ -80,15 +78,13 @@ class TimetableContentItem extends React.Component<PropsType> {
                 </Link>
               )
             }
-            <div className='tagWrapper'>
-             {difficultyKo && difficultyEn && (
+            {difficultyKo && difficultyEn && (
               <TagWrapper>
                 <Tag className={difficultyEn && difficultyEn.toLowerCase()}>
                   {difficultyKo}
                 </Tag>
               </TagWrapper>
             )}
-            </div>
           </div>
         </div>
       </TimeTableContentItem>


### PR DESCRIPTION
타임테이블 태그 스타일 변경

- 모바일에서 타이틀이 밀려 너무 작은 현상 해결
- 태그 늘어나도 영역에서 벗어나지 않게 처리

**화면변경 후**

Desktop
![스크린샷, 2019-07-30 22-23-31](https://user-images.githubusercontent.com/32350596/62132967-fdca6e80-b318-11e9-8237-5b91317f64d6.png)

Mobile
![스크린샷, 2019-07-30 22-23-10](https://user-images.githubusercontent.com/32350596/62132977-015df580-b319-11e9-848e-cd333a07c155.png)
